### PR TITLE
replace deprecated oauth2client.tools.run() with run_flow().

### DIFF
--- a/gdcmdtools/auth.py
+++ b/gdcmdtools/auth.py
@@ -4,7 +4,7 @@
 import os
 from oauth2client.file import Storage
 from oauth2client.client import flow_from_clientsecrets
-from oauth2client.tools import run
+from oauth2client.tools import run_flow
 from apiclient.discovery import build
 
 from gdcmdtools.base import BASE_INFO
@@ -120,9 +120,9 @@ class GDAuth(object):
 
             else:
                 try:
-                    credentials = run(flow, storage)
+                    credentials = run_flow(flow, storage)
                 except:
-                    logger.error("failed on oauth2client.tools.run()")
+                    logger.error("failed on oauth2client.tools.run_flow()")
                     return None
 
         self.credentials = credentials

--- a/gdcmdtools/base.py
+++ b/gdcmdtools/base.py
@@ -4,7 +4,6 @@
 import os
 from oauth2client.file import Storage
 from oauth2client.client import flow_from_clientsecrets
-from oauth2client.tools import run
 from apiclient.discovery import build
 
 import httplib2
@@ -18,7 +17,7 @@ logger.setLevel(logging.INFO)
 BASE_INFO = {
         "app":"gdcmdtools",
         "description":'Google Drive command line tools',
-        "version":'0.95'}
+        "version":'0.96'}
 
 GDAPI_VER = 'v2'
 FTAPI_VER = 'v1'


### PR DESCRIPTION
upstream oauth2client.tools removed run(). Replaced it with run_flow(). 
bumped version to 0.96